### PR TITLE
Add new __riscv_abi_rve macro.

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -34,6 +34,7 @@ https://creativecommons.org/licenses/by/4.0/.
 ## Preprocessor Definitions
 
 * `__riscv`
+* `__riscv_abi_rve`
 * `__riscv_32e`
 * `__riscv_xlen`
 * `__riscv_flen`


### PR DESCRIPTION
Defined when -mabi=ilp32e is used.
