### PR TITLE
Add __riscv_vector and __riscv_bitmanip for V and B extensions.

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -52,6 +52,8 @@ https://creativecommons.org/licenses/by/4.0/.
 * `__riscv_cmodel_medlow`
 * `__riscv_cmodel_medany`
 * `__riscv_cmodel_pic`
+* `__riscv_vector`
+* `__riscv_bitmanip`
 
 ## Function Attributes
 


### PR DESCRIPTION
We have assembler ports for the V and B extensions, so we should be thinking about adding preprocessor macros for them.  __riscv_vector seems straightforward.  __riscv_bitmanipulation seems inconveniently long, but __riscv_bitmanip looks OK, and is consistent with the B extension gas/gcc patches.  I asked in a riscv/riscv-bitmanip issue if they are OK with this.  We should wait for comments in case they want to suggest something different.
