### PR TITLE
Introduce new scheme of extension related predefined macro

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -55,8 +55,8 @@ https://creativecommons.org/licenses/by/4.0/.
 
 Architecture extension test macro is a new set of test macro to checking the
 availability and version for certain extension, however not all compilers are
-supported, so you should check `__riscv_arch_test_macro` to make sure this
-compiler is supporting those preprocessor definitions.
+supported, so you should check `__riscv_arch_test` to make sure this compiler
+is supporting those preprocessor definitions.
 
 The value of architecture extension test macro are defined as its version,
 which is compute by following formula:
@@ -71,7 +71,7 @@ For example:
 
 | Name                    | Value        | When defined                  |
 | ----------------------- | ------------ | ----------------------------- |
-| __riscv_arch_test_macro | 1            | Defined if compiler support new architecture extension test macro. |
+| __riscv_arch_test       | 1            | Defined if compiler support new architecture extension test macro. |
 | __riscv_i               | Arch Version | `I` extension is available.   |
 | __riscv_e               | Arch Version | `E` extension is available.   |
 | __riscv_m               | Arch Version | `M` extension is available.   |

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -39,15 +39,11 @@ https://creativecommons.org/licenses/by/4.0/.
 | __riscv_xlen        | <ul><li>32 for rv32</li><li>64 for rv64</li><li>128 for rv128</ul> | Always defined.             |
 | __riscv_flen        | <ul><li>32 if the F extension is available **or**</li><li>64 if `D` extension available **or**</li><li>128 if `Q` extension available</li></ul> | `F` extension is available. |
 | __riscv_32e         | 1     | `E` extension is available.   |
-| __riscv_atomic      | 1     | `A` extension is available.   |
-| __riscv_compressed  | 1     | `C` extension is available.   |
 | __riscv_mul         | 1     | `M` extension is available.   |
 | __riscv_div         | 1     | `M` extension is available and `-mno-div` is not given.*[1]    |
 | __riscv_muldiv      | 1     | `M` extension is available and `-mno-div` is not given.*[1]    |
 | __riscv_fdiv        | 1     | `F` extension is available and `-mno-fdiv` is not given.*[1]   |
 | __riscv_fsqrt       | 1     | `F` extension is available and `-mno-fdiv` is not given.*[1]   |
-| __riscv_vector      | 1     | `V` extension is available.   |
-| __riscv_bitmanip    | 1     | `B` extension is available.   |
 
 *[1] Not all compilers provide `-mno-div` and `-mno-fdiv` option.
 
@@ -105,6 +101,11 @@ For example:
 | Name                  | Value    | When defined                          | Alternative |
 | --------------------- | -------- | ------------------------------------- | ----------- |
 | __riscv_cmodel_pic    | 1        | GCC defines this when compiling with `-fPIC`, `-fpic`, `-fPIE` or `-fpie`. | `__PIC__` or `__PIE__` |
+| __riscv_atomic        | 1        | `A` extension is available.   |
+| __riscv_compressed    | 1        | `C` extension is available.   |
+| __riscv_vector        | 1        | `V` extension is available.   |
+| __riscv_bitmanip      | 1        | `B` extension is available.   |
+
 
 ## Function Attributes
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -48,9 +48,40 @@ https://creativecommons.org/licenses/by/4.0/.
 | __riscv_fsqrt       | 1     | `F` extension is available and `-mno-fdiv` is not given.*[1]   |
 | __riscv_vector      | 1     | `V` extension is available.   |
 | __riscv_bitmanip    | 1     | `B` extension is available.   |
-| __riscv_zfh         | 1     | `Zfh` extension is available. |
 
 *[1] Not all compilers provide `-mno-div` and `-mno-fdiv` option.
+
+### Architecture Extension Test Macro
+
+Architecture extension test macro is a new set of test macro to checking the
+availability and version for certain extension, however not all compilers are
+supported, so you should check `__riscv_arch_test_macro` to make sure this
+compiler is supporting those preprocessor definitions.
+
+The value of architecture extension test macro are defined as its version,
+which is compute by following formula:
+
+```
+<MAJOR_VERSION> * 1,000,000 + <MINOR_VERSION> * 1,000 + <REVISION_VERSION>
+```
+
+For example:
+- F-extension v2.2 will define `__riscv_f` as `20002000`.
+- B-extension v0.92 will define `__riscv_b` as `92000`.
+
+| Name                    | Value        | When defined                  |
+| ----------------------- | ------------ | ----------------------------- |
+| __riscv_arch_test_macro | 1            | Defined if compiler support new architecture extension test macro. |
+| __riscv_i               | Arch Version | `I` extension is available.   |
+| __riscv_e               | Arch Version | `E` extension is available.   |
+| __riscv_m               | Arch Version | `M` extension is available.   |
+| __riscv_a               | Arch Version | `A` extension is available.   |
+| __riscv_f               | Arch Version | `F` extension is available.   |
+| __riscv_d               | Arch Version | `D` extension is available.   |
+| __riscv_c               | Arch Version | `C` extension is available.   |
+| __riscv_b               | Arch Version | `B` extension is available.   |
+| __riscv_v               | Arch Version | `V` extension is available.   |
+| __riscv_zfh             | Arch Version | `Zfh` extension is available. |
 
 ### ABI Related Preprocessor Definitions
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -39,13 +39,6 @@ https://creativecommons.org/licenses/by/4.0/.
 | __riscv_xlen        | <ul><li>32 for rv32</li><li>64 for rv64</li><li>128 for rv128</ul> | Always defined.             |
 | __riscv_flen        | <ul><li>32 if the F extension is available **or**</li><li>64 if `D` extension available **or**</li><li>128 if `Q` extension available</li></ul> | `F` extension is available. |
 | __riscv_32e         | 1     | `E` extension is available.   |
-| __riscv_mul         | 1     | `M` extension is available.   |
-| __riscv_div         | 1     | `M` extension is available and `-mno-div` is not given.*[1]    |
-| __riscv_muldiv      | 1     | `M` extension is available and `-mno-div` is not given.*[1]    |
-| __riscv_fdiv        | 1     | `F` extension is available and `-mno-fdiv` is not given.*[1]   |
-| __riscv_fsqrt       | 1     | `F` extension is available and `-mno-fdiv` is not given.*[1]   |
-
-*[1] Not all compilers provide `-mno-div` and `-mno-fdiv` option.
 
 ### Architecture Extension Test Macro
 
@@ -101,11 +94,17 @@ For example:
 | Name                  | Value    | When defined                          | Alternative |
 | --------------------- | -------- | ------------------------------------- | ----------- |
 | __riscv_cmodel_pic    | 1        | GCC defines this when compiling with `-fPIC`, `-fpic`, `-fPIE` or `-fpie`. | `__PIC__` or `__PIE__` |
+| __riscv_mul           | 1        | `M` extension is available.   |
+| __riscv_div           | 1        | `M` extension is available and `-mno-div` is not given.*[1]    |
+| __riscv_muldiv        | 1        | `M` extension is available and `-mno-div` is not given.*[1]    |
 | __riscv_atomic        | 1        | `A` extension is available.   |
+| __riscv_fdiv          | 1        | `F` extension is available and `-mno-fdiv` is not given.*[1]   |
+| __riscv_fsqrt         | 1        | `F` extension is available and `-mno-fdiv` is not given.*[1]   |
 | __riscv_compressed    | 1        | `C` extension is available.   |
 | __riscv_vector        | 1        | `V` extension is available.   |
 | __riscv_bitmanip      | 1        | `B` extension is available.   |
 
+*[1] Not all compilers provide `-mno-div` and `-mno-fdiv` option.
 
 ## Function Attributes
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -94,15 +94,15 @@ For example:
 | Name                  | Value    | When defined                          | Alternative |
 | --------------------- | -------- | ------------------------------------- | ----------- |
 | __riscv_cmodel_pic    | 1        | GCC defines this when compiling with `-fPIC`, `-fpic`, `-fPIE` or `-fpie`. | `__PIC__` or `__PIE__` |
-| __riscv_mul           | 1        | `M` extension is available.   |
-| __riscv_div           | 1        | `M` extension is available and `-mno-div` is not given.*[1]    |
-| __riscv_muldiv        | 1        | `M` extension is available and `-mno-div` is not given.*[1]    |
-| __riscv_atomic        | 1        | `A` extension is available.   |
-| __riscv_fdiv          | 1        | `F` extension is available and `-mno-fdiv` is not given.*[1]   |
-| __riscv_fsqrt         | 1        | `F` extension is available and `-mno-fdiv` is not given.*[1]   |
-| __riscv_compressed    | 1        | `C` extension is available.   |
-| __riscv_vector        | 1        | `V` extension is available.   |
-| __riscv_bitmanip      | 1        | `B` extension is available.   |
+| __riscv_mul           | 1        | `M` extension is available.   | `__riscv_m` |
+| __riscv_div           | 1        | `M` extension is available and `-mno-div` is not given.*[1]    | `__riscv_m` |
+| __riscv_muldiv        | 1        | `M` extension is available and `-mno-div` is not given.*[1]    | `__riscv_m` |
+| __riscv_atomic        | 1        | `A` extension is available.   | `__riscv_a` |
+| __riscv_fdiv          | 1        | `F` extension is available and `-mno-fdiv` is not given.*[1]   | `__riscv_f` or `__riscv_d` |
+| __riscv_fsqrt         | 1        | `F` extension is available and `-mno-fdiv` is not given.*[1]   | `__riscv_f` or `__riscv_d` |
+| __riscv_compressed    | 1        | `C` extension is available.   | `__riscv_c` |
+| __riscv_vector        | 1        | `V` extension is available.   | `__riscv_v` |
+| __riscv_bitmanip      | 1        | `B` extension is available.   | `__riscv_b` |
 
 *[1] Not all compilers provide `-mno-div` and `-mno-fdiv` option.
 


### PR DESCRIPTION
The motivation of this scheme is have an unify naming scheme for
extension macro and add the capability to checking version.

The new naming scheme is `__riscv_<extension name>`, and it will define
the value to `<MAJOR_VERSION> * 1,000,000 + <MINOR_VERSION> * 1,000 + <REVISION_VERSION>`

For example:
 - F-extension v2.2 will define `__riscv_f` as `20002000`.
 - B-extension v0.92 will define `__riscv_b` as `92000`.

We also introduce a new macro `__riscv_arch_test_marco` to check this
test marco set is available.